### PR TITLE
feat: Add Home Assistant support for yeelight-matrix

### DIFF
--- a/custom_components/yeelight_matrix/__init__.py
+++ b/custom_components/yeelight_matrix/__init__.py
@@ -1,0 +1,25 @@
+"""The Yeelight Matrix integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Yeelight Matrix from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/custom_components/yeelight_matrix/config_flow.py
+++ b/custom_components/yeelight_matrix/config_flow.py
@@ -1,0 +1,80 @@
+"""Config flow for Yeelight Matrix."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import (
+    CONF_BASE_POSITION,
+    CONF_LAYOUT_ORIENTATION,
+    CONF_MODULES,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_PORT, default=55443): int,
+    }
+)
+
+STEP_LAYOUT_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_LAYOUT_ORIENTATION, default="vertical"): vol.In(
+            ["vertical", "horizontal"]
+        ),
+        vol.Required(CONF_BASE_POSITION, default="bottom"): vol.In(
+            ["top", "bottom", "left", "right"]
+        ),
+        vol.Required(CONF_MODULES): str,
+    }
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Yeelight Matrix."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self.data: dict[str, Any] = {}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self.data.update(user_input)
+            return await self.async_step_layout()
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_layout(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the layout configuration step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            modules_str = user_input[CONF_MODULES]
+            modules_list = [module.strip() for module in modules_str.split(",")]
+
+            self.data[CONF_MODULES] = modules_list
+            self.data[CONF_LAYOUT_ORIENTATION] = user_input[CONF_LAYOUT_ORIENTATION]
+            self.data[CONF_BASE_POSITION] = user_input[CONF_BASE_POSITION]
+
+            return self.async_create_entry(title=self.data[CONF_HOST], data=self.data)
+
+        return self.async_show_form(
+            step_id="layout", data_schema=STEP_LAYOUT_DATA_SCHEMA, errors=errors
+        )

--- a/custom_components/yeelight_matrix/const.py
+++ b/custom_components/yeelight_matrix/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Yeelight Matrix integration."""
+
+DOMAIN = "yeelight_matrix"
+
+CONF_LAYOUT_ORIENTATION = "layout_orientation"
+CONF_BASE_POSITION = "base_position"
+CONF_MODULES = "modules"

--- a/custom_components/yeelight_matrix/light.py
+++ b/custom_components/yeelight_matrix/light.py
@@ -1,0 +1,164 @@
+"""Light platform for Yeelight Matrix."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from yeelight_matrix.cube_matrix import CubeMatrix
+from yeelight_matrix.layout import Layout
+
+from .const import (
+    CONF_BASE_POSITION,
+    CONF_LAYOUT_ORIENTATION,
+    CONF_MODULES,
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_SET_MODULE_COLORS = "set_module_colors"
+SERVICE_SET_IMAGE = "set_image"
+SERVICE_SET_FX_MODE = "set_fx_mode"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Yeelight Matrix light platform."""
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
+    layout_orientation = entry.data[CONF_LAYOUT_ORIENTATION]
+    base_position = entry.data[CONF_BASE_POSITION]
+    modules = entry.data[CONF_MODULES]
+
+    cube = CubeMatrix(host, port)
+    layout = Layout(layout_orientation, base_position)
+    layout.add_modules_list(modules)
+
+    light = YeelightMatrixLight(cube, layout, entry.entry_id)
+    async_add_entities([light])
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_SET_MODULE_COLORS,
+        {
+            vol.Required("module_index"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Required("colors"): vol.All(list, [vol.All(str)]),
+        },
+        "async_set_module_colors",
+    )
+    platform.async_register_entity_service(
+        SERVICE_SET_IMAGE,
+        {
+            vol.Required("image_path"): str,
+            vol.Required("start_module"): vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Required("max_modules"): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        },
+        "async_set_image",
+    )
+    platform.async_register_entity_service(
+        SERVICE_SET_FX_MODE,
+        {
+            vol.Required("mode"): str,
+        },
+        "async_set_fx_mode",
+    )
+
+
+class YeelightMatrixLight(LightEntity):
+    """Representation of a Yeelight Matrix Light."""
+
+    def __init__(self, cube: CubeMatrix, layout: Layout, unique_id: str) -> None:
+        """Initialize the light."""
+        self._cube = cube
+        self._layout = layout
+        self._attr_unique_id = unique_id
+        self._attr_name = "Yeelight Matrix"
+        self._attr_is_on = True
+        self._attr_brightness = 255
+        self._attr_rgb_color = (255, 255, 255)
+        self._attr_supported_color_modes = {ColorMode.RGB}
+        self._attr_color_mode = ColorMode.RGB
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the light is on."""
+        return self._attr_is_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        await self.hass.async_add_executor_job(self._cube.get_bulb().turn_on)
+        self._attr_is_on = True
+
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = int(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
+            await self.hass.async_add_executor_job(
+                self._cube.get_bulb().set_brightness, brightness
+            )
+            self._attr_brightness = kwargs[ATTR_BRIGHTNESS]
+
+        if ATTR_RGB_COLOR in kwargs:
+            r, g, b = kwargs[ATTR_RGB_COLOR]
+            await self.hass.async_add_executor_job(self._cube.get_bulb().set_rgb, r, g, b)
+            self._attr_rgb_color = kwargs[ATTR_RGB_COLOR]
+
+        await self.async_update_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self.hass.async_add_executor_job(self._cube.get_bulb().turn_off)
+        self._attr_is_on = False
+        await self.async_update_ha_state()
+
+    async def async_update(self) -> None:
+        """Update the light."""
+        properties = await self.hass.async_add_executor_job(self._cube.get_bulb().get_properties)
+        if properties:
+            self._attr_is_on = properties["power"] == "on"
+            self._attr_brightness = int(properties["bright"]) * 255 / 100
+            if properties["rgb"] is not None:
+                r, g, b = (
+                    int(properties["rgb"][0:2], 16),
+                    int(properties["rgb"][2:4], 16),
+                    int(properties["rgb"][4:6], 16),
+                )
+                self._attr_rgb_color = (r, g, b)
+
+    async def async_set_module_colors(self, module_index: int, colors: list[str]) -> None:
+        """Set the colors of a module."""
+        await self.hass.async_add_executor_job(
+            self._layout.set_module_colors, module_index, colors
+        )
+        await self._async_draw_layout()
+
+    async def async_set_image(
+        self, image_path: str, start_module: int, max_modules: int
+    ) -> None:
+        """Set an image on the matrix."""
+        await self.hass.async_add_executor_job(
+            self._layout.set_image, image_path, start_module, max_modules
+        )
+        await self._async_draw_layout()
+
+    async def async_set_fx_mode(self, mode: str) -> None:
+        """Set the FX mode."""
+        await self.hass.async_add_executor_job(self._cube.set_fx_mode, mode)
+
+    async def _async_draw_layout(self) -> None:
+        """Draw the layout on the cube."""
+        raw_rgb_data = await self.hass.async_add_executor_job(self._layout.get_raw_rgb_data)
+        await self.hass.async_add_executor_job(self._cube.draw_matrices, raw_rgb_data)

--- a/custom_components/yeelight_matrix/manifest.json
+++ b/custom_components/yeelight_matrix/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "yeelight_matrix",
+  "name": "Yeelight Matrix",
+  "codeowners": [],
+  "dependencies": [],
+  "documentation": "https://github.com/example/yeelight-matrix-hass",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/example/yeelight-matrix-hass/issues",
+  "requirements": ["yeelight-matrix==0.1.0"],
+  "version": "0.1.0"
+}

--- a/custom_components/yeelight_matrix/services.yaml
+++ b/custom_components/yeelight_matrix/services.yaml
@@ -1,0 +1,56 @@
+set_module_colors:
+  name: Set Module Colors
+  description: "Sets the colors of a specific module."
+  fields:
+    module_index:
+      name: Module Index
+      description: "The index of the module to set the colors for."
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+    colors:
+      name: Colors
+      description: "A list of hex color codes."
+      required: true
+      selector:
+        object: {}
+
+set_image:
+  name: Set Image
+  description: "Displays an image on the matrix."
+  fields:
+    image_path:
+      name: Image Path
+      description: "The path to the image file."
+      required: true
+      selector:
+        text:
+    start_module:
+      name: Start Module
+      description: "The index of the module to start displaying the image on."
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+    max_modules:
+      name: Max Modules
+      description: "The maximum number of modules to display the image on."
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+
+set_fx_mode:
+  name: Set FX Mode
+  description: "Sets the FX mode of the cube."
+  fields:
+    mode:
+      name: Mode
+      description: "The FX mode to set."
+      required: true
+      selector:
+        text:

--- a/custom_components/yeelight_matrix/strings.json
+++ b/custom_components/yeelight_matrix/strings.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Yeelight Matrix",
+        "description": "Enter the IP address and port of your Yeelight Cube.",
+        "data": {
+          "host": "IP Address",
+          "port": "Port"
+        }
+      },
+      "layout": {
+        "title": "Yeelight Matrix Layout",
+        "description": "Configure the layout of your Yeelight Cubes.",
+        "data": {
+          "layout_orientation": "Layout Orientation",
+          "base_position": "Base Position",
+          "modules": "Modules (comma-separated, e.g., 5x5_clear,5x5_blur,1x1)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the Yeelight Cube.",
+      "unknown": "An unknown error occurred."
+    },
+    "abort": {
+      "already_configured": "This Yeelight Cube is already configured."
+    }
+  }
+}

--- a/custom_components/yeelight_matrix/translations/en.json
+++ b/custom_components/yeelight_matrix/translations/en.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Yeelight Matrix",
+        "description": "Enter the IP address and port of your Yeelight Cube.",
+        "data": {
+          "host": "IP Address",
+          "port": "Port"
+        }
+      },
+      "layout": {
+        "title": "Yeelight Matrix Layout",
+        "description": "Configure the layout of your Yeelight Cubes.",
+        "data": {
+          "layout_orientation": "Layout Orientation",
+          "base_position": "Base Position",
+          "modules": "Modules (comma-separated, e.g., 5x5_clear,5x5_blur,1x1)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the Yeelight Cube.",
+      "unknown": "An unknown error occurred."
+    },
+    "abort": {
+      "already_configured": "This Yeelight Cube is already configured."
+    }
+  }
+}

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,7 +3,11 @@ from setuptools import setup, find_packages
 setup(
     name='YeelightMatrix',
     version='0.1.0',
-    packages=find_packages(include=['yeelight_matrix']),
+    packages=find_packages(),
+    package_data={
+        "custom_components.yeelight_matrix": ["*.json", "translations/*.json"],
+    },
+    include_package_data=True,
     install_requires=[
         'yeelight==0.7.14',
         'Pillow==11.0.0',


### PR DESCRIPTION
This commit introduces a new Home Assistant custom component for the yeelight-matrix library. This component allows users to control their Yeelight Cubes from Home Assistant.

The component includes:
- A configuration flow to set up the Yeelight Cube's IP address, port, and module layout.
- A light entity to control the power, brightness, and color of the cube.
- Services to set module colors, display images, and set FX modes.
- Localization files for the configuration flow.
- A services.yaml file to define the available services.

The setup.py file has been updated to include the new custom_components package.