### PR TITLE
fix: Add config_flow support and update manifest

### DIFF
--- a/custom_components/yeelight_matrix/manifest.json
+++ b/custom_components/yeelight_matrix/manifest.json
@@ -1,11 +1,14 @@
 {
   "domain": "yeelight_matrix",
   "name": "Yeelight Matrix",
+  "config_flow": true,
   "codeowners": [],
   "dependencies": [],
-  "documentation": "https://github.com/example/yeelight-matrix-hass",
+  "documentation": "https://github.com/VladFlorinIlie/YeelightMatrix",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/example/yeelight-matrix-hass/issues",
-  "requirements": ["yeelight-matrix==0.1.0"],
-  "version": "0.1.0"
+  "issue_tracker": "https://github.com/VladFlorinIlie/YeelightMatrix/issues",
+  "requirements": [
+    "yeelight-matrix==0.1.0"
+  ],
+  "version": "0.1.1"
 }


### PR DESCRIPTION
This commit fixes an issue where the integration was not being correctly identified by HACS as using a config flow.

- Adds `"config_flow": true` to `manifest.json`.
- Bumps the version to `0.1.1` to allow HACS to pick up the change.
- Updates the documentation and issue tracker URLs to point to the correct GitHub repository.