### PR TITLE
fix: Correct PyPI package name in manifest

### DIFF
--- a/custom_components/yeelight_matrix/manifest.json
+++ b/custom_components/yeelight_matrix/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/VladFlorinIlie/YeelightMatrix/issues",
   "requirements": [
-    "yeelight-matrix==0.1.0"
+    "YeelightMatrix==0.1.0"
   ],
   "version": "0.1.1"
 }


### PR DESCRIPTION
The package name in `setup.py` is `YeelightMatrix`, but was incorrectly listed as `yeelight-matrix` in the integration's requirements.

This change corrects the name to `YeelightMatrix` to ensure Home Assistant can install the dependency from PyPI.